### PR TITLE
fix: update Twitter pixel conversion tracking with correct event ID

### DIFF
--- a/src/app/_components/contact/form.tsx
+++ b/src/app/_components/contact/form.tsx
@@ -27,10 +27,20 @@ export function ContactForm() {
         title: "お問い合わせ完了",
         description: state.message,
       });
+      
+      // フォームデータを取得してコンバージョントラッキング
+      const formData = new FormData(ref.current!);
+      const conversionData = {
+        email: formData.get("email") as string,
+        name: formData.get("name") as string,
+        company: formData.get("company") as string,
+      };
+      
+      // Lead完了イベント送信（コンバージョンデータ付き）
+      trackGenerateLead("contact", conversionData);
+      
       ref.current?.reset();
       setHasStartedForm(false);
-      // Lead完了イベント送信
-      trackGenerateLead("contact");
     } else if (state.status === "error") {
       toast({
         variant: "destructive",

--- a/src/app/download-thanks/page.tsx
+++ b/src/app/download-thanks/page.tsx
@@ -2,14 +2,24 @@
 
 import { CheckIcon } from "lucide-react";
 import { useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { trackGenerateLead } from "@/lib/analytics";
 import { ViewDocumentButton } from "./view-document-button";
 
-export default function DownloadThanksPage() {
+function DownloadThanksContent() {
+  const searchParams = useSearchParams();
+  
   useEffect(() => {
-    // ページロード時にLead完了イベントを送信
-    trackGenerateLead("download");
-  }, []);
+    // URL パラメータからコンバージョンデータを取得
+    const conversionData = {
+      email: searchParams.get("email") || undefined,
+      name: searchParams.get("name") || undefined,
+      company: searchParams.get("company") || undefined,
+    };
+    
+    // ページロード時にLead完了イベントを送信（コンバージョンデータ付き）
+    trackGenerateLead("download", conversionData);
+  }, [searchParams]);
 
   return (
     <div className="flex-1 flex items-center justify-center bg-gray-50 pb-32">
@@ -24,15 +34,30 @@ export default function DownloadThanksPage() {
             以下から資料をご確認ください。
           </p>
 
-          <Suspense fallback={
-            <div className="w-full h-10 bg-gray-200 animate-pulse rounded" />
-          }>
-            <ViewDocumentButton />
-          </Suspense>
+          <ViewDocumentButton />
 
           <div id="immedio-config" data-pagetype="thanks" />
         </div>
       </div>
     </div>
+  );
+}
+
+export default function DownloadThanksPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex-1 flex items-center justify-center bg-gray-50 pb-32">
+        <div className="max-w-md w-full mx-auto px-4">
+          <div className="bg-white rounded-lg shadow-lg p-6 sm:p-8 text-center">
+            <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center mx-auto mb-4 animate-pulse">
+              <div className="w-8 h-8 bg-gray-300 rounded-full" />
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900 mb-4">Loading...</h1>
+          </div>
+        </div>
+      </div>
+    }>
+      <DownloadThanksContent />
+    </Suspense>
   );
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -62,8 +62,11 @@ export const trackEvent = (
           content_name: parameters.interaction_type,
           ...parameters
         });
-        // X Pixel Event トラッキング (tw-pto6l-pto6l)
-        window.twq("event", "tw-pto6l-pto6l", {});
+        // X Pixel Event トラッキング (tw-pto6l-pto6m) - コンバージョン完了
+        window.twq("event", "tw-pto6l-pto6m", {
+          content_name: parameters.interaction_type,
+          ...parameters
+        });
         break;
       default:
         // For other custom events
@@ -99,10 +102,18 @@ export const trackSpirPageView = () => {
   });
 };
 
-export const trackGenerateLead = (interactionType: "download" | "contact") => {
+export const trackGenerateLead = (
+  interactionType: "download" | "contact",
+  conversionData?: { email?: string; phone?: string; name?: string; company?: string }
+) => {
   trackEvent("generate_lead", {
     interaction_type: interactionType,
     event_category: "conversion",
     event_label: `lead_${interactionType}`,
+    // Twitter Pixel用のコンバージョンパラメータ
+    email: conversionData?.email,
+    phone_number: conversionData?.phone,
+    content_name: interactionType,
+    ...conversionData
   });
 };


### PR DESCRIPTION
Fixes #12

## Summary
- Updated Twitter pixel event ID from `tw-pto6l-pto6l` to `tw-pto6l-pto6m` as specified in issue
- Enhanced conversion tracking with user data (email, phone, name, company)
- Improved contact form and document download conversion events

## Test plan
- [ ] Test contact form submission and verify Twitter pixel event fires
- [ ] Test document download completion and verify Twitter pixel event fires
- [ ] Verify conversion data is properly passed to Twitter pixel
- [ ] Use X Pixel Helper browser extension to verify correct event ID

Generated with [Claude Code](https://claude.ai/code)