### PR TITLE
fix: revert CTA text from "資料を見る"/"資料を受け取る" back to original "ダウンロード"

### DIFF
--- a/src/app/_components/cto-partner/cto-partner-hero.tsx
+++ b/src/app/_components/cto-partner/cto-partner-hero.tsx
@@ -60,7 +60,7 @@ export function CtoPartnerHero() {
         
           </p>
           <div className="hidden md:flex flex-col sm:flex-row gap-4 pt-8">
-            <DownloadButton variant="primary" iconPosition="left">資料を見る</DownloadButton>
+            <DownloadButton variant="primary" iconPosition="left">ダウンロード</DownloadButton>
             <ContactButton aggressive iconPosition="left" />
           </div>
         </div>
@@ -136,7 +136,7 @@ export function CtoPartnerHero() {
       <div className="md:hidden bg-emerald-50 py-8">
         <div className="container mx-auto px-4">
           <div className="flex flex-col sm:flex-row justify-center gap-4">
-            <DownloadButton variant="primary" iconPosition="left">資料を見る</DownloadButton>
+            <DownloadButton variant="primary" iconPosition="left">ダウンロード</DownloadButton>
             <ContactButton aggressive iconPosition="left" />
           </div>
         </div>

--- a/src/app/_components/download-button.tsx
+++ b/src/app/_components/download-button.tsx
@@ -117,7 +117,7 @@ export function DownloadButton({
             {iconPosition === "left" && !finishing && (
               <FileText className="h-4 w-4" />
             )}
-            {finishing ? "送信中..." : children || "資料を見る"}
+            {finishing ? "送信中..." : children || "ダウンロード"}
             {iconPosition === "right" && !finishing && (
               <FileText className="h-4 w-4" />
             )}
@@ -136,7 +136,7 @@ export function DownloadButton({
             <div className="bg-emerald-50 p-6 md:p-8 space-y-4 md:space-y-6">
               <div>
                 <h2 className="text-xl sm:text-2xl font-bold text-gray-900 mb-2">
-                  資料を受け取る
+                  ダウンロード
                 </h2>
                 <p className="text-gray-700 text-sm">
                   非エンジニア創業者向け{" "}
@@ -380,7 +380,7 @@ export function DownloadButton({
                     className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium h-10 sm:h-12 text-base"
                     disabled={finishing}
                   >
-                    {finishing ? "送信中..." : "資料を受け取る"}
+                    {finishing ? "送信中..." : "ダウンロード"}
                   </Button>
                 </div>
                 {state.status === "error" && !state.errors?.length && (

--- a/src/app/_components/engagement-style.tsx
+++ b/src/app/_components/engagement-style.tsx
@@ -129,7 +129,7 @@ export function EngagementStyle() {
               className="inline-flex items-center justify-center border border-emerald-600 text-emerald-600 bg-white hover:bg-emerald-50 font-medium py-3 px-8 rounded-full text-base transition-colors"
               iconPosition="right"
             >
-              資料を見る
+              ダウンロード
             </DownloadButton>
           </div>
         </div>

--- a/src/app/_components/service-plans.tsx
+++ b/src/app/_components/service-plans.tsx
@@ -112,7 +112,7 @@ export function ServicePlans() {
                 </p>
               </div>
               <DownloadButton variant="primary" iconPosition="left">
-                資料を見る
+                ダウンロード
               </DownloadButton>
             </div>
           </div>

--- a/src/app/download-thanks/view-document-button.tsx
+++ b/src/app/download-thanks/view-document-button.tsx
@@ -27,7 +27,7 @@ export function ViewDocumentButton() {
       onClick={handleViewDocument}
     >
       <ExternalLink className="mr-2 h-4 w-4" />
-      資料を見る
+      ダウンロード
     </Button>
   );
 }


### PR DESCRIPTION
Reverts recent CTA text changes back to original "ダウンロード" text across all affected components.

Based on evidence found in commented code in cto-partner-cta.tsx showing original "サービス資料をダウンロード" pattern.

## Changes:
- Reverted 8 instances across 5 files
- All "資料を見る" and "資料を受け取る" text reverted to "ダウンロード"

Fixes #15

Generated with [Claude Code](https://claude.ai/code)