### PR TITLE
feat: Add HubSpot contact creation for form submissions

### DIFF
--- a/HUBSPOT_SETUP.md
+++ b/HUBSPOT_SETUP.md
@@ -1,0 +1,93 @@
+# HubSpot Integration Setup
+
+This document explains how to set up HubSpot integration for automatic contact creation when users submit inquiry forms or request documents.
+
+## Required Environment Variables
+
+Add the following environment variable to your Vercel deployment:
+
+```bash
+HUBSPOT_ACCESS_TOKEN=your_hubspot_access_token_here
+```
+
+## HubSpot Setup Instructions
+
+### 1. Create a HubSpot App or Get Access Token
+
+#### Option A: Private App (Recommended)
+1. Go to your HubSpot account settings
+2. Navigate to **Integrations** > **Private Apps**
+3. Click **Create a private app**
+4. Give your app a name (e.g., "Reminus Website Integration")
+5. In the **Scopes** tab, select the following permissions:
+   - `crm.objects.contacts.write` - Required for creating/updating contacts
+   - `crm.objects.contacts.read` - Optional, for reading existing contacts
+6. Click **Create app**
+7. Copy the generated access token
+
+#### Option B: OAuth App
+1. Create an OAuth app in HubSpot developer settings
+2. Follow HubSpot's OAuth flow to get an access token
+3. Ensure the app has the required scopes mentioned above
+
+### 2. Configure Environment Variables in Vercel
+
+1. Go to your Vercel project dashboard
+2. Navigate to **Settings** > **Environment Variables**
+3. Add the following variable:
+   - **Name**: `HUBSPOT_ACCESS_TOKEN`
+   - **Value**: Your HubSpot access token
+   - **Environment**: Production, Preview, Development (as needed)
+4. Redeploy your application
+
+### 3. Test the Integration
+
+1. Submit a form on your website
+2. Check your HubSpot contacts to verify the contact was created
+3. Check your application logs for any HubSpot-related errors
+
+## How It Works
+
+When a user submits either form:
+
+1. **Contact/Inquiry Form**: Creates a HubSpot contact with email, name, company, and stores the inquiry message
+2. **Document Request Form**: Creates a HubSpot contact with email, name, company, and phone number
+
+The integration uses HubSpot's batch upsert API, which means:
+- If a contact with the same email already exists, it will be updated
+- If no contact exists, a new one will be created
+- Email is used as the unique identifier
+
+## Error Handling
+
+The HubSpot integration is designed to be non-blocking:
+- If HubSpot is unavailable or there's an API error, the form submission will still succeed
+- Errors are logged to the console but don't prevent the user from completing their action
+- If the `HUBSPOT_ACCESS_TOKEN` environment variable is not set, HubSpot integration will be skipped with a warning
+
+## Troubleshooting
+
+### Common Issues
+
+1. **403 Forbidden Error**: Check that your access token has the required scopes
+2. **401 Unauthorized Error**: Verify your access token is correct and hasn't expired
+3. **Contacts not appearing**: Check that the email address format is valid and the API call is successful
+
+### Debug Logs
+
+Check your Vercel function logs for HubSpot-related messages:
+- Success: "Successfully created/updated HubSpot contact: [email]"
+- Warning: "HubSpot access token not configured. Skipping contact creation."
+- Error: "Error creating HubSpot contact: [error details]"
+
+## Alternative: Zapier Integration
+
+If you prefer using Zapier instead of direct API integration:
+
+1. Remove the HubSpot integration code
+2. Set up a Zapier webhook trigger
+3. Configure the webhook URL in your environment variables
+4. Modify the form actions to send data to the Zapier webhook
+5. Create a Zapier workflow that receives the webhook data and creates HubSpot contacts
+
+The direct API approach is recommended for better performance and fewer dependencies.

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -2,6 +2,7 @@
 
 import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
+import { hubspotService } from "@/lib/hubspot";
 
 const prisma = new PrismaClient();
 
@@ -72,6 +73,14 @@ export async function submitInquiry(
         ...validatedFields,
         content: validatedFields.content || "",
       },
+    });
+
+    // HubSpotにコンタクトを作成
+    await hubspotService.createInquiryContact({
+      email: validatedFields.email,
+      name: validatedFields.name,
+      company: validatedFields.company,
+      content: validatedFields.content,
     });
 
     // Slack通知を送信
@@ -148,6 +157,14 @@ export async function requestDocument(
 
     await prisma.documentRequest.create({
       data: validatedFields,
+    });
+
+    // HubSpotにコンタクトを作成
+    await hubspotService.createDocumentRequestContact({
+      email: validatedFields.email,
+      name: validatedFields.name,
+      company: validatedFields.company,
+      phone: validatedFields.phone,
     });
 
     const params = new URLSearchParams({

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -1,0 +1,167 @@
+// HubSpot API integration for contact creation
+// Docs: https://developers.hubspot.com/docs/api/crm/contacts
+
+export interface HubSpotContactData {
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  company?: string;
+  phone?: string;
+  message?: string;
+}
+
+export interface HubSpotContact {
+  id: string;
+  properties: {
+    email: string;
+    firstname?: string;
+    lastname?: string;
+    company?: string;
+    phone?: string;
+    createdate: string;
+    lastmodifieddate: string;
+  };
+}
+
+class HubSpotService {
+  private accessToken: string;
+  private baseUrl = "https://api.hubapi.com";
+
+  constructor() {
+    this.accessToken = process.env.HUBSPOT_ACCESS_TOKEN || "";
+    
+    if (!this.accessToken) {
+      console.warn("HubSpot access token not configured. Contact creation will be skipped.");
+    }
+  }
+
+  private async makeRequest<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...options,
+      headers: {
+        "Authorization": `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `HubSpot API error: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Create or update a contact in HubSpot
+   * Uses email as the unique identifier
+   */
+  async createOrUpdateContact(data: HubSpotContactData): Promise<HubSpotContact | null> {
+    if (!this.accessToken) {
+      console.warn("HubSpot access token not configured. Skipping contact creation.");
+      return null;
+    }
+
+    try {
+      // Parse name into first and last name if provided
+      let firstname: string | undefined;
+      let lastname: string | undefined;
+      
+      if (data.firstname) {
+        // If firstname is provided directly, use it as-is
+        firstname = data.firstname;
+        lastname = data.lastname;
+      } else {
+        // If we have a full name in firstname field or need to parse
+        const nameParts = (data.firstname || "").trim().split(/\s+/);
+        if (nameParts.length > 0 && nameParts[0]) {
+          firstname = nameParts[0];
+          if (nameParts.length > 1) {
+            lastname = nameParts.slice(1).join(" ");
+          }
+        }
+      }
+
+      const properties: Record<string, string> = {
+        email: data.email,
+      };
+
+      if (firstname) properties.firstname = firstname;
+      if (lastname) properties.lastname = lastname;
+      if (data.company) properties.company = data.company;
+      if (data.phone) properties.phone = data.phone;
+      if (data.message) properties.message = data.message;
+
+      // Use the contacts batch upsert API to create or update based on email
+      const response = await this.makeRequest<{ results: HubSpotContact[] }>(
+        "/crm/v3/objects/contacts/batch/upsert",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            inputs: [
+              {
+                idProperty: "email",
+                id: data.email,
+                properties,
+              },
+            ],
+          }),
+        }
+      );
+
+      if (response.results && response.results.length > 0) {
+        console.log(`Successfully created/updated HubSpot contact: ${data.email}`);
+        return response.results[0];
+      }
+
+      return null;
+    } catch (error) {
+      console.error("Error creating HubSpot contact:", error);
+      // Don't throw error to prevent form submission failure
+      return null;
+    }
+  }
+
+  /**
+   * Create a contact specifically for inquiry forms
+   */
+  async createInquiryContact(data: {
+    email: string;
+    name?: string;
+    company?: string;
+    content?: string;
+  }): Promise<HubSpotContact | null> {
+    return this.createOrUpdateContact({
+      email: data.email,
+      firstname: data.name,
+      company: data.company,
+      message: data.content,
+    });
+  }
+
+  /**
+   * Create a contact specifically for document requests
+   */
+  async createDocumentRequestContact(data: {
+    email: string;
+    name: string;
+    company: string;
+    phone: string;
+  }): Promise<HubSpotContact | null> {
+    return this.createOrUpdateContact({
+      email: data.email,
+      firstname: data.name,
+      company: data.company,
+      phone: data.phone,
+    });
+  }
+}
+
+// Export singleton instance
+export const hubspotService = new HubSpotService();


### PR DESCRIPTION
Implements HubSpot contact creation for CV requests and inquiry forms as requested in issue #44.

## Changes
- Add HubSpot service with contact creation/update functionality
- Integrate HubSpot contact creation into inquiry and document request forms
- Use email-based upsert to avoid duplicate contacts
- Add non-blocking error handling to prevent form submission failures
- Include comprehensive setup documentation for HubSpot integration
- Support for Vercel environment variable configuration

## Setup Required
Add `HUBSPOT_ACCESS_TOKEN` environment variable to Vercel – see HUBSPOT_SETUP.md for detailed instructions.

Closes #44

Generated with [Claude Code](https://claude.ai/code)