### PR TITLE
feat: add no-index robots meta to contact and download-thanks pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,6 +6,9 @@ import { SchedulingButton } from "./scheduling-button";
 export const metadata: Metadata = {
   title: "お問い合わせ | Reminus",
   description: "Reminusへのお問い合わせはこちらから。",
+  robots: {
+    index: false,
+  },
 };
 
 export default function ContactPage() {

--- a/src/app/download-thanks/download-thanks-content.tsx
+++ b/src/app/download-thanks/download-thanks-content.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { CheckIcon } from "lucide-react";
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { trackGenerateLead } from "@/lib/analytics";
+import { ViewDocumentButton } from "./view-document-button";
+
+export function DownloadThanksContent() {
+  const searchParams = useSearchParams();
+  
+  useEffect(() => {
+    // URL パラメータからコンバージョンデータを取得
+    const conversionData = {
+      email: searchParams.get("email") || undefined,
+      name: searchParams.get("name") || undefined,
+      company: searchParams.get("company") || undefined,
+    };
+    
+    // ページロード時にLead完了イベントを送信（コンバージョンデータ付き）
+    trackGenerateLead("download", conversionData);
+  }, [searchParams]);
+
+  return (
+    <div className="flex-1 flex items-center justify-center bg-gray-50 pb-32">
+      <div className="max-w-md w-full mx-auto px-4">
+        <div className="bg-white rounded-lg shadow-lg p-6 sm:p-8 text-center">
+          <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <CheckIcon className="w-8 h-8 text-emerald-600" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">送信完了</h1>
+          <p className="text-gray-600 mb-2">資料請求ありがとうございます。</p>
+          <p className="text-gray-600 mb-6">
+            以下から資料をご確認ください。
+          </p>
+
+          <ViewDocumentButton />
+
+          <div id="immedio-config" data-pagetype="thanks" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/download-thanks/page.tsx
+++ b/src/app/download-thanks/page.tsx
@@ -1,47 +1,16 @@
-"use client";
-
 import { CheckIcon } from "lucide-react";
-import { useEffect, Suspense } from "react";
-import { useSearchParams } from "next/navigation";
-import { trackGenerateLead } from "@/lib/analytics";
+import { Suspense } from "react";
+import { Metadata } from "next";
 import { ViewDocumentButton } from "./view-document-button";
+import { DownloadThanksContent } from "./download-thanks-content";
 
-function DownloadThanksContent() {
-  const searchParams = useSearchParams();
-  
-  useEffect(() => {
-    // URL パラメータからコンバージョンデータを取得
-    const conversionData = {
-      email: searchParams.get("email") || undefined,
-      name: searchParams.get("name") || undefined,
-      company: searchParams.get("company") || undefined,
-    };
-    
-    // ページロード時にLead完了イベントを送信（コンバージョンデータ付き）
-    trackGenerateLead("download", conversionData);
-  }, [searchParams]);
-
-  return (
-    <div className="flex-1 flex items-center justify-center bg-gray-50 pb-32">
-      <div className="max-w-md w-full mx-auto px-4">
-        <div className="bg-white rounded-lg shadow-lg p-6 sm:p-8 text-center">
-          <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <CheckIcon className="w-8 h-8 text-emerald-600" />
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">送信完了</h1>
-          <p className="text-gray-600 mb-2">資料請求ありがとうございます。</p>
-          <p className="text-gray-600 mb-6">
-            以下から資料をご確認ください。
-          </p>
-
-          <ViewDocumentButton />
-
-          <div id="immedio-config" data-pagetype="thanks" />
-        </div>
-      </div>
-    </div>
-  );
-}
+export const metadata: Metadata = {
+  title: "送信完了 | Reminus",
+  description: "資料請求ありがとうございます。",
+  robots: {
+    index: false,
+  },
+};
 
 export default function DownloadThanksPage() {
   return (

--- a/src/app/download-thanks/page.tsx
+++ b/src/app/download-thanks/page.tsx
@@ -1,7 +1,5 @@
-import { CheckIcon } from "lucide-react";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { ViewDocumentButton } from "./view-document-button";
 import { DownloadThanksContent } from "./download-thanks-content";
 
 export const metadata: Metadata = {


### PR DESCRIPTION
Add no-index robots meta tags to contact form and thank you pages

## Changes
- Add robots: { index: false } to contact page metadata
- Refactor download-thanks page to support server-side metadata
- Extract client logic to separate component for proper SSR
- Add no-index robots meta to download-thanks page

Closes #47

Generated with [Claude Code](https://claude.ai/code)