### PR TITLE
style: sp-first-view

### DIFF
--- a/src/app/_components/sections/client-logos.tsx
+++ b/src/app/_components/sections/client-logos.tsx
@@ -48,9 +48,9 @@ const clientLogos = [
 
 export function ClientLogos() {
   return (
-    <Section className="py-6 sm:py-12 md:py-16" fullWidth="all">
+    <Section className="py-8 md:py-12" fullWidth="all">
       <div className="space-y-6 sm:space-y-8">
-        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-x-6 gap-y-6 md:gap-x-12 md:gap-y-8">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-x-6 gap-y-4 md:gap-x-12 md:gap-y-8">
           {clientLogos.map((client, index) => (
             <div key={index} className="flex items-center justify-center">
               <div className="block sm:hidden">

--- a/src/app/_components/sections/first-view.tsx
+++ b/src/app/_components/sections/first-view.tsx
@@ -11,7 +11,7 @@ export function FirstView() {
         <SubTitle />
         <Title className="mt-2" />
         <Description className="mt-2 sm:mt-4" />
-        <div className="mt-6 flex justify-center sm:mt-8 lg:hidden">
+        <div className="mt-5 flex justify-center sm:mt-8 lg:hidden">
           <Image
             src="/hero.png"
             alt=""
@@ -22,7 +22,7 @@ export function FirstView() {
             className="w-[90%] max-w-[544px]"
           />
         </div>
-        <div className="mx-auto mt-8 max-w-[340px] space-y-5 sm:mt-8 lg:mx-0">
+        <div className="mx-auto mt-7 max-w-[340px] space-y-5 sm:mt-8 lg:mx-0">
           <DownloadButton
             fullWidth
             className="shadow-xl shadow-emerald-100/50"


### PR DESCRIPTION
## WHY
* spのfirst viewでボタン見えきってないのがCVR上微妙なのでなんとかしたい
* ついでにロゴも見えたい


## 実装

* とにかく詰める
  * 装飾 + タグラインで4行が多すぎるのでなんとかする
  * paddingを切り詰める
* 無料相談消す
  * 早くロゴを見せたい

## 備考

* デザインは適当。目的はとにかくボタン、できればロゴが見えたい。以上。手段はどうでもいい

before:

<img src="https://github.com/user-attachments/assets/c4fff2b5-ac52-4d00-93a3-ea9e0a12455e" width="30%">

after:

<img src="https://github.com/user-attachments/assets/c60a18a6-77b1-4df3-a5fb-f8a0c9c50435" width="30%">

