### PR TITLE
fix(middleware): AB テスト redirect で UTM クエリを保持する

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,7 +20,9 @@ export function middleware(request: NextRequest) {
   if (process.env.APP_ENVIRONMENT === "development") {
     // /a は / にリダイレクト
     if (pathname === "/a") {
-      return NextResponse.redirect(new URL("/", request.url));
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url);
     }
     // /b, /c, / はそのまま表示
     return NextResponse.next();
@@ -28,7 +30,9 @@ export function middleware(request: NextRequest) {
 
   // /a: cookie を a に固定して / にリダイレクト（URL は / として表示される）
   if (pathname === "/a") {
-    const response = NextResponse.redirect(new URL("/", request.url));
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    const response = NextResponse.redirect(url);
     response.cookies.set(AB_TEST_COOKIE, "a", COOKIE_OPTIONS);
     return response;
   }
@@ -64,8 +68,13 @@ export function middleware(request: NextRequest) {
   const needsCookieUpdate = existingVariant !== variant;
 
   // a 以外はそのバリアントのパスにリダイレクト
+  // pathname のみ書き換え、search (utm_* 等) と hash は保持する。
+  // これをしないと Meta 広告等の UTM クエリが redirect で落ち、
+  // GA4 のセッション参照元 / メディアが meta/paid_social として計測されなくなる。
   if (variant !== "a") {
-    const response = NextResponse.redirect(new URL(`/${variant}`, request.url));
+    const url = request.nextUrl.clone();
+    url.pathname = `/${variant}`;
+    const response = NextResponse.redirect(url);
     if (needsCookieUpdate) {
       response.cookies.set(AB_TEST_COOKIE, variant, COOKIE_OPTIONS);
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,7 @@ export function middleware(request: NextRequest) {
   const existingVariant = request.cookies.get(AB_TEST_COOKIE)?.value;
 
   // development 環境では A/B テストをスキップし、各バリアントをそのまま表示する
-  if (process.env.APP_ENVIRONMENT === "development") {
+  if (process.env.APP_ENVIRONMENT === "development" && process.env.ABTEST !== "enabled") {
     // /a は / にリダイレクト
     if (pathname === "/a") {
       const url = request.nextUrl.clone();


### PR DESCRIPTION
Meta 広告等で `/?utm_source=meta&utm_medium=paid_social` に着地した ユーザーが /b, /c に振り分けられる際、`new URL('/b', request.url)` の 挙動で search と hash が落ちていた。

結果として GA4 のセッション参照元 / メディアが meta/paid_social と
して計測されず、ファネルで AB バリアント別に絞り込んだ際に b, c の
トラフィックが除外される状態になっていた。

`request.nextUrl.clone()` で search と hash を保持したまま pathname だけ書き換えるように変更。